### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The following tables represent the weighted means and the 99% confidence interva
 
 | Algorithm | Log Loss | RMSE | RMSE(bins) |
 | --- | --- | --- | --- |
-| FSRS-4.5 | 0.37±0.085 | 0.33±0.045 | 0.06±0.027 |
-| SM-17 | 0.41±0.097 | 0.34±0.046 | 0.10±0.039 |
-| FSRSv3 | 0.40±0.093 | 0.34±0.045 | 0.10±0.028 |
-| SM-16 | 0.42±0.086 | 0.35±0.041 | 0.12±0.026 |
+| FSRS-4.5 | 0.4±0.09 | 0.33±0.045 | 0.06±0.027 |
+| FSRSv3 | 0.4±0.09 | 0.34±0.045 | 0.10±0.027 |
+| SM-17 | 0.4±0.10 | 0.34±0.046 | 0.10±0.039 |
+| SM-16 | 0.4±0.09 | 0.35±0.041 | 0.12±0.026 |
 
 Smaller is better. If you are unsure what number to look at, look at RMSE (bins). That value can be interpreted as "the average difference between the predicted probability of recalling a card and the measured probability". For example, if RMSE (bins)=0.05, it means that that algorithm is, on average, wrong by 5% when predicting the probability of recall.
 
@@ -35,10 +35,10 @@ Smaller is better. If you are unsure what number to look at, look at RMSE (bins)
 
 | Algorithm | Log Loss | RMSE | RMSE(bins) |
 | --- | --- | --- | --- |
-| FSRS-4.5 | 0.42±0.078 | 0.35±0.040 | 0.09±0.037 |
-| SM-17 | 0.5±0.10 | 0.36±0.046 | 0.11±0.036 |
+| FSRS-4.5 | 0.4±0.08 | 0.35±0.040 | 0.09±0.037 |
 | FSRSv3 | 0.5±0.10 | 0.36±0.044 | 0.12±0.034 |
-| SM-16 | 0.5±0.11 | 0.37±0.045 | 0.13±0.033 |
+| SM-17 | 0.5±0.10 | 0.36±0.046 | 0.11±0.035 |
+| SM-16 | 0.5±0.11 | 0.37±0.045 | 0.13±0.032 |
 
 Smaller is better.
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -31,7 +31,7 @@ def sigdig(value, CI):
                 return int(digit)
 
     n_lead_zeros_CI = num_lead_zeros(CI)
-    CI_sigdigs = min(len(str(CI)[2 + n_lead_zeros_CI:]), 2)  # assumes CI<1
+    CI_sigdigs = min(len(str(CI)[2 + n_lead_zeros_CI:]), 2)
     decimals = n_lead_zeros_CI + CI_sigdigs
     rounded_CI = round(CI, decimals)
     first_sigdig_CI = first_nonzero_digit(rounded_CI)


### PR DESCRIPTION
I have extended the rule regarding significant digits. There was a problem with the original rule ("The last sig-dig in the mean value is at the same decimal place as the first sig-dig (the first non-zero) in the confidence interval"). Let's look at two examples: 10.5±0.1 and 10.5±0.5.
In the first example, we know that the last digit can off by 1 in either direction, so it could be 4, 5 or 6. We know that the last digit is definitely not 1 and definitely not 9. So while there is some uncertainty, it's not completely random. Therefore it makes sense to report it.
In the second example, the last digit can be off by 5 in either direction. So it could anything from 0 to 9. If it could be anything, that means it's just noise. Therefore we shouldn't report it.
Now I'll try to figure out how to also add evaluate.py to this pull request - I have made an ugly function that does all of the rounding.